### PR TITLE
include bool header for ruby 3.4

### DIFF
--- a/ext/geoip2/geoip2.c
+++ b/ext/geoip2/geoip2.c
@@ -1,3 +1,4 @@
+#include <stdbool.h>
 #include <ruby.h>
 #include <ruby/encoding.h>
 #include <maxminddb.h>

--- a/ext/geoip2/rb_compat.h
+++ b/ext/geoip2/rb_compat.h
@@ -1,6 +1,7 @@
 #ifndef __RB_COMPAT_H__
 #define __RB_COMPAT_H__
 
+#include <stdbool.h>
 #include <ruby.h>
 
 #ifndef HAVE_RB_SYM2STR


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/21290

support 'CFLAGS=-std=gnu99' on ruby 3.4 and above (which removed #include <stdbool.h> from the ruby headers).

I think this is good practice, and if we are maintaining this gem we should probably add it.
It's also completely inadequate because so many gems are broken in this way and i think the real problem is that you have to build ruby with at least

CFLAGS=-std=gnu17 

which.. i'm surprised.. given that i install an [app](https://github.com/rbenv/ruby-build) just to build ruby for me.. but it doesnt seem to have an opinion on that

